### PR TITLE
Return values instead of echoing

### DIFF
--- a/src/LangleyFoxall/Modules/Helpers/Config.php
+++ b/src/LangleyFoxall/Modules/Helpers/Config.php
@@ -2,8 +2,6 @@
 
 namespace LangleyFoxall\Modules\Helpers;
 
-use Illuminate\Support\Str;
-
 abstract class Config
 {
 	protected $config = [];

--- a/src/LangleyFoxall/Modules/Helpers/Config.php
+++ b/src/LangleyFoxall/Modules/Helpers/Config.php
@@ -23,10 +23,9 @@ abstract class Config
 	 */
 	public function __get($variable)
 	{
-		$key = Str::snake($variable);
 
-		if (array_key_exists($key, $this->config)) {
-			return $this->config[ $key ];
+		if (array_key_exists($variable, $this->config)) {
+			return $this->config[ $variable ];
 		}
 
 		return '';
@@ -43,10 +42,8 @@ abstract class Config
 			return $this->{$method}(...$args);
 		}
 
-		$key = Str::snake($method);
-
-		if (array_key_exists($key, $this->config)) {
-			return $this->config[ $key ];
+		if (array_key_exists($method, $this->config)) {
+			return $this->config[ $method ];
 		}
 
 		return null;

--- a/src/LangleyFoxall/Modules/Helpers/Config.php
+++ b/src/LangleyFoxall/Modules/Helpers/Config.php
@@ -26,10 +26,10 @@ abstract class Config
 		$key = Str::snake($variable);
 
 		if (array_key_exists($key, $this->config)) {
-			echo $this->config[ $key ];
+			return $this->config[ $key ];
 		}
 
-		echo '';
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
This means that we can use the getter for values without rendering onto the page, we need to change the side menu nav to use ```{!!}``` in the CRM.